### PR TITLE
split() is deprecated, using explode() instead

### DIFF
--- a/vatValidation.class.php
+++ b/vatValidation.class.php
@@ -86,7 +86,7 @@ class vatValidation
         }
                         
         $newString = "";
-        $words = split(" ",$string);
+        $words = explode(" ",$string);
         foreach($words as $k=>$w)
         {                       
            	$newString .= ucfirst(strtolower($w))." "; 


### PR DESCRIPTION
split() is deprecated, using explode() instead
